### PR TITLE
feat: new flag for non https support

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,4 +14,6 @@ type Config struct {
 	Path string
 	// cookie domain
 	Domain string
+	// set this true for non https
+	Unsecure bool
 }

--- a/csrf.go
+++ b/csrf.go
@@ -70,7 +70,7 @@ func (c *CSRF) Inject(handler fastglue.FastRequestHandler) fastglue.FastRequestH
 			Value:    value,
 			MaxAge:   c.cfg.MaxAge,
 			Path:     c.cfg.Path,
-			Secure:   true,
+			Secure:   !c.cfg.Unsecure,
 			HttpOnly: true,
 			SameSite: http.SameSite(c.cfg.SameSite),
 			Domain:   c.cfg.Domain,
@@ -152,7 +152,7 @@ func (c *CSRF) deny(r *fastglue.Request) {
 		Value:    "",
 		Expires:  fasthttp.CookieExpireDelete,
 		Path:     "/",
-		Secure:   true,
+		Secure:   !c.cfg.Unsecure,
 		HttpOnly: true,
 	}, r)
 


### PR DESCRIPTION
When testing in local environments, the default `secure=true` may cause issues in non HTTPS endpoints. 
`Unsecure` flag in `config.go` can help if one wants to explicitly specify to use `secure=false`. 
This new flag shouldn't cause issues in existing implementations since default will still remain `secure=true`.